### PR TITLE
fix: correct package name for backoff

### DIFF
--- a/content/packages/backoff-rxjs/index.md
+++ b/content/packages/backoff-rxjs/index.md
@@ -1,9 +1,9 @@
 ---
-title: "rxjs-backoff"
+title: "backoff-rxjs"
 description: A collection of helpful RxJS operators to deal with backoff strategies (like exponential backoff)
 author: "Alex Okrushko"
 authorGitHub: "alex-okrushko"
-packageGitHub: "alex-okrushko/rxjs-backoff"
+packageGitHub: "alex-okrushko/backoff-rxjs"
 date: "2020-05-22T15:17:00+1000"
 categories: []
 keywords: []
@@ -11,4 +11,4 @@ keywords: []
 
 A collection of helpful RxJS operators to deal with backoff strategies (like exponential backoff)
 
-[README.md](https://github.com/alex-okrushko/rxjs-backoff/blob/master/README.md)
+[README.md](https://github.com/alex-okrushko/backoff-rxjs/blob/master/README.md)


### PR DESCRIPTION
rxjs-backoff is not my package, and that name was already taken when I was adding the package, so I went with `backoff-rxjs`. Probably not the best naming choice but as you say "naming is hard" 🙂