### PR TITLE
Add @react-rxjs/core

### DIFF
--- a/content/packages/react-rxjs__core/index.md
+++ b/content/packages/react-rxjs__core/index.md
@@ -1,0 +1,16 @@
+---
+title: "@react-rxjs/core"
+description: "React bindings for RxJS"
+author: ["Josep M Sobrepere", "Victor Oliva"]
+authorGitHub: ["josepot", "voliva"]
+packageGitHub: "re-rxjs/react-rxjs"
+date: "2020-09-09T21:35:47+2000"
+categories: ["state-management"]
+keywords: ["react", "react-suspense", "react-hooks", "typescript"]
+---
+
+React-RxJS is a library that offers React bindings for RxJS
+
+[README.md](https://github.com/re-rxjs/react-rxjs/blob/main/README.md)
+
+[Website][https://re-rxjs.github.io/react-rxjs.org]


### PR DESCRIPTION
Hi and thanks a lot for creating this!

Would it be ok to add `@react-rxjs/core` into the list of RxJS Community Packages?

Also, a couple of questions:

1) Is there a way to have 2 authors for the same package? I'm asking this because if possible I would like to add Victor Oliva as a Co-Author of the library.

2) Is it ok to add a link to a gh-pages site (i.e `https://re-rxjs.github.io/react-rxjs.org`), if that link redirects to a custom domain? I didn't do it because I thought that it was not in the spirit of the "contributing" instructions, but if you told me that's fair game, then I would add the link.

Thanks!